### PR TITLE
merge package template from arlac77/npm-package-template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-coverage
 package-lock.json
 node_modules
 build
 dist
-out
 *.log
 *.dump
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-coverage
 build
 tests
 doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 8.9.3
+  - 9
 sudo: false
 branches:
   only:
@@ -17,13 +18,14 @@ before_install:
   - npm i -g npm@latest
 before_script:
   - npm prune
-  - npm install -g codecov
-  - npm install coveralls
+  - npm install -g --production coveralls codecov
 script:
   - npm run cover
+  - npm run lint
+  - npm run docs
 after_script:
   - codecov
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - cat ./build/coverage/lcov.info | coveralls
   - npm run docs
 after_success:
   - npm run semantic-release

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, darlenya & arlac77
+Copyright (c) 2015,2017 darlenya & arlac77
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 [![npm](https://img.shields.io/npm/v/kronos-flow-control-step.svg)](https://www.npmjs.com/package/kronos-flow-control-step)
+[![Greenkeeper](https://badges.greenkeeper.io/Kronos-Integration/kronos-flow-control-step.svg)](https://greenkeeper.io/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/Kronos-Integration/kronos-flow-control-step)
+[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![Build Status](https://secure.travis-ci.org/Kronos-Integration/kronos-flow-control-step.png)](http://travis-ci.org/Kronos-Integration/kronos-flow-control-step)
 [![bithound](https://www.bithound.io/github/Kronos-Integration/kronos-flow-control-step/badges/score.svg)](https://www.bithound.io/github/Kronos-Integration/kronos-flow-control-step)
 [![codecov.io](http://codecov.io/github/Kronos-Integration/kronos-flow-control-step/coverage.svg?branch=master)](http://codecov.io/github/Kronos-Integration/kronos-flow-control-step?branch=master)
-[![Code Climate](https://codeclimate.com/github/Kronos-Integration/kronos-flow-control-step/badges/gpa.svg)](https://codeclimate.com/github/Kronos-Integration/kronos-flow-control-step)
+[![Coverage Status](https://coveralls.io/repos/Kronos-Integration/kronos-flow-control-step/badge.svg)](https://coveralls.io/r/Kronos-Integration/kronos-flow-control-step)
+[![Known Vulnerabilities](https://snyk.io/test/github/Kronos-Integration/kronos-flow-control-step/badge.svg)](https://snyk.io/test/github/Kronos-Integration/kronos-flow-control-step)
 [![GitHub Issues](https://img.shields.io/github/issues/Kronos-Integration/kronos-flow-control-step.svg?style=flat-square)](https://github.com/Kronos-Integration/kronos-flow-control-step/issues)
+[![Stories in Ready](https://badge.waffle.io/Kronos-Integration/kronos-flow-control-step.svg?label=ready&title=Ready)](http://waffle.io/Kronos-Integration/kronos-flow-control-step)
 [![Dependency Status](https://david-dm.org/Kronos-Integration/kronos-flow-control-step.svg)](https://david-dm.org/Kronos-Integration/kronos-flow-control-step)
 [![devDependency Status](https://david-dm.org/Kronos-Integration/kronos-flow-control-step/dev-status.svg)](https://david-dm.org/Kronos-Integration/kronos-flow-control-step#info=devDependencies)
 [![docs](http://inch-ci.org/github/Kronos-Integration/kronos-flow-control-step.svg?branch=master)](http://inch-ci.org/github/Kronos-Integration/kronos-flow-control-step)
+[![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo)
 [![downloads](http://img.shields.io/npm/dm/kronos-flow-control-step.svg?style=flat-square)](https://npmjs.org/package/kronos-flow-control-step)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
@@ -16,7 +21,6 @@ Step to perform flow controlling actions like load delete stop start
 Command endpoint
 ================
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/Kronos-Integration/kronos-flow-control-step.svg)](https://greenkeeper.io/)
 
 A Request can either be a stream o json data or a an object with data property.
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,16 @@
   ],
   "main": "flow_control.js",
   "scripts": {
-    "cover": "./node_modules/istanbul/lib/cli.js cover --hook-run-in-context ./node_modules/mocha/bin/_mocha -- --R spec --U exports tests/*_test.js",
+    "cover": "nyc --temp-directory build/nyc ava",
     "doc": "./node_modules/.bin/jsdoc lib/*.js",
-    "test": "./node_modules/.bin/mocha tests/*_test.js",
-    "semantic-release": "semantic-release"
+    "test": "ava",
+    "semantic-release": "semantic-release",
+    "precover": "rollup -c tests/rollup.config.js",
+    "pretest": "rollup -c tests/rollup.config.js",
+    "posttest": "npm run prepare && markdown-doctest",
+    "prepare": "rollup -c",
+    "docs": "documentation readme {{module}} --section=API",
+    "lint": "documentation lint {{module}}"
   },
   "repository": {
     "type": "git",
@@ -25,17 +31,20 @@
     "kronos-step": "^5.6.4"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "cz-conventional-changelog": "2.1.0",
-    "istanbul": "0.4.5",
-    "jsdoc": "3.5.5",
     "kronos-flow": "^2.5.39",
     "kronos-interceptor-decode-json": "^1.0.11",
     "kronos-service-manager": "^3.5.1",
     "kronos-step-stdio": "^3.0.18",
     "kronos-test-step": "3.1.4",
-    "mocha": "^3.5.3",
-    "semantic-release": "^11.1.0"
+    "semantic-release": "^11.1.0",
+    "documentation": "^5.3.5",
+    "markdown-doctest": "^0.9.1",
+    "nyc": "^11.4.1",
+    "ava": "^0.24.0",
+    "rollup": "^0.53.0",
+    "rollup-plugin-babel": "^3.0.3",
+    "rollup-plugin-multi-entry": "^2.0.2",
+    "xo": "^0.19.0"
   },
   "contributors": [
     {
@@ -56,7 +65,27 @@
   },
   "template": {
     "repository": {
-      "url": "https://github.com/Kronos-Tools/npm-package-template-minimal.git"
+      "url": "https://github.com/arlac77/npm-package-template.git"
     }
+  },
+  "ava": {
+    "files": [
+      "build/*-test.js"
+    ],
+    "presets": [
+      "env"
+    ],
+    "require": [
+      "babel-register"
+    ]
+  },
+  "nyc": {
+    "include": [
+      "build/*-test.js"
+    ],
+    "reporter": [
+      "lcov"
+    ],
+    "report-dir": "./build/coverage"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+import babel from 'rollup-plugin-babel';
+import pkg from './package.json';
+
+export default {
+  input: pkg.module,
+  output: {
+    file: pkg.main,
+    format: 'cjs'
+  },
+  plugins: [
+    babel({
+      babelrc: false,
+      presets: ['env'],
+      exclude: 'node_modules/**'
+    })
+  ]
+};

--- a/tests/rollup.config.js
+++ b/tests/rollup.config.js
@@ -1,0 +1,20 @@
+import babel from 'rollup-plugin-babel';
+import multiEntry from 'rollup-plugin-multi-entry';
+
+export default {
+  input: 'tests/**/*-test.js',
+  output: {
+    file: 'build/bundle-test.js',
+    format: 'cjs',
+    sourcemap: true
+  },
+  external: ['ava'],
+  plugins: [
+    babel({
+      babelrc: false,
+      presets: ['env'],
+      exclude: 'node_modules/**'
+    }),
+    multiEntry()
+  ]
+};


### PR DESCRIPTION
package.json
---
- chore(devDependencies): remove jsdoc@3.5.5
- chore(devDependencies): remove istanbul@0.4.5
- chore(devDependencies): remove mocha@^3.5.3
- chore(devDependencies): remove chai@^4.1.2
- chore(devDependencies): remove cz-conventional-changelog@2.1.0
- chore(devDependencies): add documentation@^5.3.5 from template
- chore(devDependencies): add markdown-doctest@^0.9.1 from template
- chore(devDependencies): add nyc@^11.4.1 from template
- chore(devDependencies): add ava@^0.24.0 from template
- chore(devDependencies): add rollup@^0.53.0 from template
- chore(devDependencies): add rollup-plugin-babel@^3.0.3 from template
- chore(devDependencies): add rollup-plugin-multi-entry@^2.0.2 from template
- chore(devDependencies): add xo@^0.19.0 from template
- chore(scripts): update cover@nyc --temp-directory build/nyc ava from template
- chore(scripts): add precover@rollup -c tests/rollup.config.js from template
- chore(scripts): update test@ava from template
- chore(scripts): add pretest@rollup -c tests/rollup.config.js from template
- chore(scripts): add posttest@npm run prepare && markdown-doctest from template
- chore(scripts): add prepare@rollup -c from template
- chore(scripts): add docs@documentation readme {{module}} --section=API from template
- chore(scripts): add lint@documentation lint {{module}} from template
- chore(package): set template repo

.travis.yml
---
- chore(travis): merge from template .travis.yml

README.md
---
- docs(README): update from template

rollup.config.js
---
- chore(rollup): copy from template

tests/rollup.config.js
---
- chore(rollup): copy from template

LICENSE
---
- chore(license): add current year 2017

.gitignore
---
- chore(git): update .gitignore from template

.npmignore
---
- chore(npm): update .npmignore from template
